### PR TITLE
Optionally provide a simple log-facade implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ description = "Provides `print!` and `println!` implementations various Espressi
 repository  = "https://github.com/esp-rs/esp-println"
 license     = "MIT OR Apache-2.0"
 
+[dependencies]
+log         = { version = "0.4.17", optional = true }
+
 [features]
 default = ["uart"]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Provides `print!` and `println!` implementations various Espressif devices.
 
 - Supports ESP32, ESP32-C3, ESP32-S2, ESP32-S3, and ESP8266
-- Dependency free (not even depending on `esp-hal`)
+- Dependency free (not even depending on `esp-hal`, one optional dependency is `log`)
 - Supports JTAG-Serial output where available
 - Supports RTT (lacking working RTT hosts besides _probe-rs_ for ESP32-C3)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ macro_rules! print {
     };
 }
 
+#[cfg(feature = "log")]
+pub mod logger;
+
 #[cfg(feature = "esp32")]
 const UART_TX_ONE_CHAR: usize = 0x40009200;
 #[cfg(feature = "esp32c3")]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,20 @@
+pub fn init_logger(level: log::LevelFilter) {
+    unsafe {
+        log::set_logger_racy(&EspLogger).unwrap();
+        log::set_max_level(level);
+    }
+}
+
+struct EspLogger;
+
+impl log::Log for EspLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        println!("{} - {}", record.level(), record.args());
+    }
+
+    fn flush(&self) {}
+}


### PR DESCRIPTION
This addresses #5 

It's the simplest implementation possible but should still be useful.

It's behind the `log` feature. To initialize logging just call `esp_println::logger::init_logger(log::LevelFilter::Trace)` (or any other log level).