### PR TITLE
Don't enable TX-INTERRUPT on ESP32-S2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp-println"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
     "Jesse Braham <jesse@beta7.io>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,6 @@ impl core::fmt::Write for Printer {
     #[cfg(feature = "esp32s2")]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         // On ESP32-S2 the UART_TX_ONE_CHAR ROM-function seems to have some issues.
-        unsafe {
-            // enable TX_DONE interrupt
-            (0x3f40000c as *mut u32).write_volatile(1 << 14);
-        }
         for chunk in s.as_bytes().chunks(64) {
             for &b in chunk {
                 unsafe {


### PR DESCRIPTION
On ESP32-S2 the code enabled the TX-INTERRUPT - it's not necessary and can cause issues.

e.g. the `serial_interrupts` in `esp-hal` won't work when using `println!` in the example - this fixes it
Also, the crate's version is bumped to `0.2.2` to prepare a release
