### PR TITLE
Bump the version and update the README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp-println"
-version = "0.2.2"
+version = "0.3.0"
 authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
     "Jesse Braham <jesse@beta7.io>",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides `print!` and `println!` implementations various Espressif devices.
 
-- Supports ESP32, ESP32-C3, ESP32-S2, ESP32-S3, and ESP8266
+- Supports ESP32, ESP32-C2, ESP32-C3, ESP32-S2, ESP32-S3, and ESP8266
 - Dependency free (not even depending on `esp-hal`, one optional dependency is `log`)
 - Supports JTAG-Serial output where available
 - Supports RTT (lacking working RTT hosts besides _probe-rs_ for ESP32-C3)


### PR DESCRIPTION
I've confirmed that this is working for the ESP32-C2, so I'd like to release a new version so I can remove my Cargo patches. Just wanted to double-check that RTT was going to work as described in the `README` without any changes being required in the other projects.