### PR TITLE
Optional critical-section support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp-println"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
     "Jesse Braham <jesse@beta7.io>",
@@ -17,6 +17,7 @@ cargo-args = ["-Z", "build-std=core"]
 
 [dependencies]
 log = { version = "0.4.17", optional = true }
+critical-section = { version = "1.1.1", optional = true }
 
 [features]
 default = ["uart"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Provides `print!` and `println!` implementations various Espressif devices.
 
 - Supports ESP32, ESP32-C2, ESP32-C3, ESP32-S2, ESP32-S3, and ESP8266
-- Dependency free (not even depending on `esp-hal`, one optional dependency is `log`)
+- Dependency free (not even depending on `esp-hal`, one optional dependency is `log`, another is `critical-section`)
 - Supports JTAG-Serial output where available
 - Supports RTT (lacking working RTT hosts besides _probe-rs_ for ESP32-C3)
 


### PR DESCRIPTION
- adds a feature `critical-section`

While for most chips not using it might just result in printing gibberish it's a real problem on ESP32-S2
This also bumps the version to `0.3.1` since an added optional dependency is just a minor change
