### PR TITLE
Add support for the ESP32-H2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ esp32   = []
 esp32c2 = []
 esp32c3 = []
 esp32c6 = []
+esp32h2 = []
 esp32s2 = []
 esp32s3 = []
 esp8266 = []
@@ -34,5 +35,5 @@ esp8266 = []
 # You must enable exactly 1 of the below features to enable to intended
 # communication method (note that "uart" is enabled by default):
 uart        = []
-jtag_serial = [] # C3, C6, and S3 only!
+jtag_serial = [] # C3, C6, H2, and S3 only!
 rtt         = []

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides `print!` and `println!` implementations various Espressif devices.
 
-- Supports ESP32, ESP32-C2, ESP32-C3, ESP32-C6, ESP32-S2, ESP32-S3, and ESP8266
+- Supports ESP32, ESP32-C2/C3/C6, ESP32-H2, ESP32-S2/S3, and ESP8266
 - Dependency free (not even depending on `esp-hal`, one optional dependency is `log`, another is `critical-section`)
 - Supports JTAG-Serial output where available
 - Supports RTT (lacking working RTT hosts besides _probe-rs_ for ESP32-C3)

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ fn main() {
         cfg!(feature = "esp32c2"),
         cfg!(feature = "esp32c3"),
         cfg!(feature = "esp32c6"),
+        cfg!(feature = "esp32h2"),
         cfg!(feature = "esp32s2"),
         cfg!(feature = "esp32s3"),
         cfg!(feature = "esp8266"),
@@ -32,7 +33,10 @@ fn main() {
     // Ensure that, if the `jtag_serial` communication method feature is enabled,
     // either the `esp32c3`, `esp32c6` or `esp32s3` chip feature is enabled.
     if cfg!(feature = "jtag_serial")
-        && !(cfg!(feature = "esp32c3") || cfg!(feature = "esp32c6") || cfg!(feature = "esp32s3"))
+        && !(cfg!(feature = "esp32c3")
+            || cfg!(feature = "esp32c6")
+            || cfg!(feature = "esp32h2")
+            || cfg!(feature = "esp32s3"))
     {
         panic!(
             "The `jtag_serial` feature is only supported by the ESP32-C3, ESP32-C6, and ESP32-S3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod logger;
 
 #[cfg(feature = "esp32")]
 const UART_TX_ONE_CHAR: usize = 0x40009200;
-#[cfg(any(feature = "esp32c2", feature = "esp32c6"))]
+#[cfg(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2"))]
 const UART_TX_ONE_CHAR: usize = 0x40000058;
 #[cfg(feature = "esp32c3")]
 const UART_TX_ONE_CHAR: usize = 0x40000068;
@@ -76,9 +76,9 @@ impl core::fmt::Write for Printer {
     }
 }
 
-#[cfg(all(feature = "jtag_serial", feature = "esp32c3"))]
+#[cfg(all(feature = "jtag_serial", any(feature = "esp32c3", feature = "esp32h2")))]
 const SERIAL_JTAG_FIFO_REG: usize = 0x6004_3000;
-#[cfg(all(feature = "jtag_serial", feature = "esp32c3"))]
+#[cfg(all(feature = "jtag_serial", any(feature = "esp32c3", feature = "esp32h2")))]
 const SERIAL_JTAG_CONF_REG: usize = 0x6004_3004;
 
 #[cfg(all(feature = "jtag_serial", feature = "esp32c6"))]
@@ -93,7 +93,12 @@ const SERIAL_JTAG_CONF_REG: usize = 0x6003_8004;
 
 #[cfg(all(
     feature = "jtag_serial",
-    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3")
+    any(
+        feature = "esp32c3",
+        feature = "esp32c6",
+        feature = "esp32h2",
+        feature = "esp32s3"
+    )
 ))]
 impl core::fmt::Write for Printer {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {


### PR DESCRIPTION
As with the C6, untested on hardware but should work. Once we get hardware we can verify both devices and publish a release at that time.