### PR TITLE
Add no-op feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ esp8266 = []
 uart        = []
 jtag_serial = [] # C3, C6, H2, and S3 only!
 rtt         = []
+no-op       = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,25 @@
 #![no_std]
 
+
+#[cfg(feature = "no-op")]
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {
+        {
+        }
+    };
+}
+
+#[cfg(feature = "no-op")]
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+        {
+        }
+    };
+}
+
+#[cfg(not(feature = "no-op"))]
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {
@@ -10,6 +30,7 @@ macro_rules! println {
     };
 }
 
+#[cfg(not(feature = "no-op"))]
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {


### PR DESCRIPTION
Not sure if this is a wanted feature, but I thought it might be useful for release builds when debugging is not necessary anymore and it saves some memory while still retaining the option to go back. 