### PR TITLE
Default to using `critical-section`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = { version = "0.4.17", optional = true }
 critical-section = { version = "1.1.1", optional = true }
 
 [features]
-default = ["uart"]
+default = ["uart", "critical-section"]
 
 # You must enable exactly 1 of the below features to support the correct chip:
 esp32   = []


### PR DESCRIPTION
I'm concerned about the soundness of this library (#26). I get letting the user have some control, but I think that the default behavior should opt for safety over speed. Therefore, consider making `critical-section` a default feature - at least until the safety can really be vetted.