### PR TITLE
Refactoring, formatting, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-riscv:
+    name: Check RISC-V
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chip: [esp32c2, esp32c3, esp32c6, esp32h2]
+        printer: ["rtt", "uart"]
+        include:
+          - chip: esp32c3
+            printer: "jtag_serial"
+          - chip: esp32c6
+            printer: "jtag_serial"
+          - chip: esp32h2
+            printer: "jtag_serial"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: riscv32imc-unknown-none-elf
+          toolchain: nightly
+          components: rust-src
+          default: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -Zbuild-std=core --no-default-features --target=riscv32imc-unknown-none-elf --features=${{ matrix.chip }},${{ matrix.printer }}
+
+  check-xtensa:
+    name: Check Xtensa
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chip: [esp32, esp32s2, esp32s3]
+        printer: ["rtt", "uart"]
+        include:
+          - chip: esp32s3
+            printer: "jtag_serial"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: esp-rs/xtensa-toolchain@v1.2
+        with:
+          default: true
+          ldproxy: false
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -Zbuild-std=core --no-default-features --target=xtensa-${{ matrix.chip }}-none-elf --features=${{ matrix.chip }},${{ matrix.printer }}
+
+  rustfmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,8 @@ fn main() {
     }
 
     // Ensure that, if the `jtag_serial` communication method feature is enabled,
-    // either the `esp32c3`, `esp32c6` or `esp32s3` chip feature is enabled.
+    // either the `esp32c3`, `esp32c6`, `esp32h2`, or `esp32s3` chip feature is
+    // enabled.
     if cfg!(feature = "jtag_serial")
         && !(cfg!(feature = "esp32c3")
             || cfg!(feature = "esp32c6")
@@ -39,7 +40,7 @@ fn main() {
             || cfg!(feature = "esp32s3"))
     {
         panic!(
-            "The `jtag_serial` feature is only supported by the ESP32-C3, ESP32-C6, and ESP32-S3"
+            "The `jtag_serial` feature is only supported by the ESP32-C3, ESP32-C6, ESP32-H2, and ESP32-S3"
         );
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,12 @@
+# Comments
+format_code_in_doc_comments = true
+normalize_comments          = true
+wrap_comments               = true
+
+# Enums
+enum_discrim_align_threshold = 25
+
+# Imports
+group_imports       = "StdExternalCrate"
+imports_granularity = "Crate"
+imports_layout      = "HorizontalVertical"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,10 @@
 #![no_std]
 
 
-#[cfg(feature = "no-op")]
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {
-        {
-        }
-    };
-}
-
-#[cfg(feature = "no-op")]
-#[macro_export]
-macro_rules! print {
-    ($($arg:tt)*) => {
-        {
-        }
-    };
-}
-
-#[cfg(not(feature = "no-op"))]
-#[macro_export]
-macro_rules! println {
-    ($($arg:tt)*) => {
+        #[cfg(not(feature = "no-op"))]
         {
             use core::fmt::Write;
             writeln!($crate::Printer, $($arg)*).ok();
@@ -30,10 +12,10 @@ macro_rules! println {
     };
 }
 
-#[cfg(not(feature = "no-op"))]
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {
+        #[cfg(not(feature = "no-op"))]
         {
             use core::fmt::Write;
             write!($crate::Printer, $($arg)*).ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
 
+#[cfg(feature = "log")]
+pub mod logger;
+#[cfg(feature = "rtt")]
+mod rtt;
 
 #[macro_export]
 macro_rules! println {
@@ -23,124 +27,122 @@ macro_rules! print {
     };
 }
 
-#[cfg(feature = "log")]
-pub mod logger;
-
-#[cfg(feature = "esp32")]
-const UART_TX_ONE_CHAR: usize = 0x40009200;
-#[cfg(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2"))]
-const UART_TX_ONE_CHAR: usize = 0x40000058;
-#[cfg(feature = "esp32c3")]
-const UART_TX_ONE_CHAR: usize = 0x40000068;
-#[cfg(feature = "esp32s3")]
-const UART_TX_ONE_CHAR: usize = 0x40000648;
-#[cfg(feature = "esp8266")]
-const UART_TX_ONE_CHAR: usize = 0x40003b30;
-
 pub struct Printer;
 
-#[cfg(feature = "uart")]
-impl core::fmt::Write for Printer {
-    #[cfg(not(feature = "esp32s2"))]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        with(|| {
-            for &b in s.as_bytes() {
-                unsafe {
-                    let uart_tx_one_char: unsafe extern "C" fn(u8) -> i32 =
-                        core::mem::transmute(UART_TX_ONE_CHAR);
-                    uart_tx_one_char(b)
-                };
-            }
-            core::fmt::Result::Ok(())
-        })
-    }
-
-    #[cfg(feature = "esp32s2")]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        with(|| {
-            // On ESP32-S2 the UART_TX_ONE_CHAR ROM-function seems to have some issues.
-            for chunk in s.as_bytes().chunks(64) {
-                for &b in chunk {
-                    unsafe {
-                        // write FIFO
-                        (0x3f400000 as *mut u32).write_volatile(b as u32);
-                    };
+#[cfg(feature = "rtt")]
+mod rtt_printer {
+    impl core::fmt::Write for super::Printer {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            super::with(|| {
+                let count = crate::rtt::write_str_internal(s);
+                if count < s.len() {
+                    crate::rtt::write_str_internal(&s[count..]);
                 }
-
-                // wait for TX_DONE
-                while unsafe { (0x3f400004 as *const u32).read_volatile() } & (1 << 14) == 0 {}
-                unsafe {
-                    // reset TX_DONE
-                    (0x3f400010 as *mut u32).write_volatile(1 << 14);
-                }
-            }
-            core::fmt::Result::Ok(())
-        })
+                core::fmt::Result::Ok(())
+            })
+        }
     }
 }
 
-#[cfg(all(feature = "jtag_serial", any(feature = "esp32c3", feature = "esp32h2")))]
-const SERIAL_JTAG_FIFO_REG: usize = 0x6004_3000;
-#[cfg(all(feature = "jtag_serial", any(feature = "esp32c3", feature = "esp32h2")))]
-const SERIAL_JTAG_CONF_REG: usize = 0x6004_3004;
+#[cfg(feature = "jtag_serial")]
+mod serial_jtag_printer {
+    #[cfg(any(feature = "esp32c3", feature = "esp32h2"))]
+    const SERIAL_JTAG_FIFO_REG: usize = 0x6004_3000;
+    #[cfg(any(feature = "esp32c3", feature = "esp32h2"))]
+    const SERIAL_JTAG_CONF_REG: usize = 0x6004_3004;
 
-#[cfg(all(feature = "jtag_serial", feature = "esp32c6"))]
-const SERIAL_JTAG_FIFO_REG: usize = 0x6000_F000;
-#[cfg(all(feature = "jtag_serial", feature = "esp32c6"))]
-const SERIAL_JTAG_CONF_REG: usize = 0x6000_F004;
+    #[cfg(feature = "esp32c6")]
+    const SERIAL_JTAG_FIFO_REG: usize = 0x6000_F000;
+    #[cfg(feature = "esp32c6")]
+    const SERIAL_JTAG_CONF_REG: usize = 0x6000_F004;
 
-#[cfg(all(feature = "jtag_serial", feature = "esp32s3"))]
-const SERIAL_JTAG_FIFO_REG: usize = 0x6003_8000;
-#[cfg(all(feature = "jtag_serial", feature = "esp32s3"))]
-const SERIAL_JTAG_CONF_REG: usize = 0x6003_8004;
+    #[cfg(feature = "esp32s3")]
+    const SERIAL_JTAG_FIFO_REG: usize = 0x6003_8000;
+    #[cfg(feature = "esp32s3")]
+    const SERIAL_JTAG_CONF_REG: usize = 0x6003_8004;
 
-#[cfg(all(
-    feature = "jtag_serial",
-    any(
+    #[cfg(any(
         feature = "esp32c3",
         feature = "esp32c6",
         feature = "esp32h2",
         feature = "esp32s3"
-    )
-))]
-impl core::fmt::Write for Printer {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        with(|| {
-            unsafe {
-                let fifo = SERIAL_JTAG_FIFO_REG as *mut u32;
-                let conf = SERIAL_JTAG_CONF_REG as *mut u32;
+    ))]
+    impl core::fmt::Write for super::Printer {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            super::with(|| {
+                unsafe {
+                    let fifo = SERIAL_JTAG_FIFO_REG as *mut u32;
+                    let conf = SERIAL_JTAG_CONF_REG as *mut u32;
 
-                // todo 64 byte chunks max
-                for chunk in s.as_bytes().chunks(32) {
-                    for &b in chunk {
-                        fifo.write_volatile(b as u32);
-                    }
-                    conf.write_volatile(0b001);
+                    // todo 64 byte chunks max
+                    for chunk in s.as_bytes().chunks(32) {
+                        for &b in chunk {
+                            fifo.write_volatile(b as u32);
+                        }
+                        conf.write_volatile(0b001);
 
-                    while conf.read_volatile() & 0b011 == 0b000 {
-                        // wait
+                        while conf.read_volatile() & 0b011 == 0b000 {
+                            // wait
+                        }
                     }
                 }
-            }
 
-            core::fmt::Result::Ok(())
-        })
+                core::fmt::Result::Ok(())
+            })
+        }
     }
 }
 
-#[cfg(feature = "rtt")]
-mod rtt;
+#[cfg(feature = "uart")]
+mod uart_printer {
+    #[cfg(feature = "esp32")]
+    const UART_TX_ONE_CHAR: usize = 0x40009200;
+    #[cfg(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2"))]
+    const UART_TX_ONE_CHAR: usize = 0x40000058;
+    #[cfg(feature = "esp32c3")]
+    const UART_TX_ONE_CHAR: usize = 0x40000068;
+    #[cfg(feature = "esp32s3")]
+    const UART_TX_ONE_CHAR: usize = 0x40000648;
+    #[cfg(feature = "esp8266")]
+    const UART_TX_ONE_CHAR: usize = 0x40003b30;
 
-#[cfg(feature = "rtt")]
-impl core::fmt::Write for Printer {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        with(|| {
-            let count = crate::rtt::write_str_internal(s);
-            if count < s.len() {
-                crate::rtt::write_str_internal(&s[count..]);
-            }
-            core::fmt::Result::Ok(())
-        })
+    impl core::fmt::Write for super::Printer {
+        #[cfg(not(feature = "esp32s2"))]
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            super::with(|| {
+                for &b in s.as_bytes() {
+                    unsafe {
+                        let uart_tx_one_char: unsafe extern "C" fn(u8) -> i32 =
+                            core::mem::transmute(UART_TX_ONE_CHAR);
+                        uart_tx_one_char(b)
+                    };
+                }
+                core::fmt::Result::Ok(())
+            })
+        }
+
+        #[cfg(feature = "esp32s2")]
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            super::with(|| {
+                // On ESP32-S2 the UART_TX_ONE_CHAR ROM-function seems to have some issues.
+                for chunk in s.as_bytes().chunks(64) {
+                    for &b in chunk {
+                        unsafe {
+                            // write FIFO
+                            (0x3f400000 as *mut u32).write_volatile(b as u32);
+                        };
+                    }
+
+                    // wait for TX_DONE
+                    while unsafe { (0x3f400004 as *const u32).read_volatile() } & (1 << 14) == 0 {}
+                    unsafe {
+                        // reset TX_DONE
+                        (0x3f400010 as *mut u32).write_volatile(1 << 14);
+                    }
+                }
+                core::fmt::Result::Ok(())
+            })
+        }
     }
 }
 


### PR DESCRIPTION
This PR is a little all over the place, but essentially:

- Fixed error message in build script
- Consolidated the `print!` and `println!` macro implementations
- Moved each implementation of the `Write` trait into a module, along with any required constants (fixes #21 and just generally cleans up the `#[cfg]`s)
- Add a `rustfmt.toml` configuration file (closes #24)
- Add a CI workflow which builds the library in each possible configuration and checks the code formatting

Successful CI run can be seen [here](https://github.com/jessebraham/esp-println/actions/runs/3525423461) on my fork.