### PR TITLE
Fix/no blocking on unconnected serial jtag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "editor.formatOnSave": true,
     "rust-analyzer.cargo.features": [
         "esp32c3",
+        "jtag_serial"
     ],
     "rust-analyzer.cargo.target": "riscv32imc-unknown-none-elf",
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ critical-section = { version = "1.1.1", optional = true }
 [features]
 default = ["uart", "critical-section"]
 
+crlf    = []
+
 # You must enable exactly 1 of the below features to support the correct chip:
 esp32   = []
 esp32c2 = []
@@ -35,6 +37,6 @@ esp8266 = []
 # You must enable exactly 1 of the below features to enable to intended
 # communication method (note that "uart" is enabled by default):
 uart        = []
-jtag_serial = [] # C3, C6, H2, and S3 only!
+jtag_serial = [ "critical-section" ] # C3, C6, H2, and S3 only!
 rtt         = []
 no-op       = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,6 @@ esp8266 = []
 # You must enable exactly 1 of the below features to enable to intended
 # communication method (note that "uart" is enabled by default):
 uart        = []
-jtag_serial = [ "critical-section" ] # C3, C6, H2, and S3 only!
+jtag_serial = [] # C3, C6, H2, and S3 only!
 rtt         = []
 no-op       = []

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # esp-println
 
-Provides `print!` and `println!` implementations various Espressif devices.
+Provides `print!` and `println!` implementations for various Espressif devices.
 
 - Supports ESP32, ESP32-C2/C3/C6, ESP32-H2, ESP32-S2/S3, and ESP8266
 - Dependency free (not even depending on `esp-hal`, one optional dependency is `log`, another is `critical-section`)
-- Supports JTAG-Serial output where available
+- Supports JTAG-Serial output where available (activates `critical-section`)
 - Supports RTT (lacking working RTT hosts besides _probe-rs_ for ESP32-C3)
+- `no-op` features turns printing into a no-op
 
 ## RTT on ESP32-C3
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Provides `print!` and `println!` implementations for various Espressif devices.
 
 - Supports ESP32, ESP32-C2/C3/C6, ESP32-H2, ESP32-S2/S3, and ESP8266
 - Dependency free (not even depending on `esp-hal`, one optional dependency is `log`, another is `critical-section`)
-- Supports JTAG-Serial output where available (activates `critical-section`)
+- Supports JTAG-Serial output where available
 - Supports RTT (lacking working RTT hosts besides _probe-rs_ for ESP32-C3)
 - `no-op` features turns printing into a no-op
 


### PR DESCRIPTION
Closes #31
Closes #32 

Additionally, this fixes the broken `no-op` feature
