### PR TITLE
Clean up serial_jtag and increase timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ mod serial_jtag_printer {
                     return;
                 }
 
-                for chunk in bytes.chunks(32) {
+                for chunk in bytes.chunks(64) {
                     for &b in chunk {
                         fifo_write(b);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,15 @@ mod rtt_printer {
     }
 }
 
-#[cfg(feature = "jtag_serial")]
+#[cfg(all(
+    feature = "jtag_serial",
+    any(
+        feature = "esp32c3",
+        feature = "esp32c6",
+        feature = "esp32h2",
+        feature = "esp32s3"
+    )
+))]
 mod serial_jtag_printer {
     #[cfg(feature = "esp32c3")]
     const SERIAL_JTAG_FIFO_REG: usize = 0x6004_3000;
@@ -122,12 +130,6 @@ mod serial_jtag_printer {
         unsafe { fifo.write_volatile(byte as u32) }
     }
 
-    #[cfg(any(
-        feature = "esp32c3",
-        feature = "esp32c6",
-        feature = "esp32h2",
-        feature = "esp32s3"
-    ))]
     impl super::Printer {
         pub fn write_bytes(&mut self, bytes: &[u8]) {
             super::with(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,11 @@ mod serial_jtag_printer {
     impl super::Printer {
         pub fn write_bytes(&mut self, bytes: &[u8]) {
             super::with(|| {
-                const TIMEOUT_ITERATIONS: usize = 5_000;
+                const TIMEOUT_ITERATIONS: usize = 50_000;
 
                 if !fifo_clear() {
-                    // still wasn't able to drain the FIFO - early return
+                    // Still wasn't able to drain the FIFO - early return
+                    // This is important so we don't block forever if there is no host attached.
                     return;
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ mod serial_jtag_printer {
 
     fn fifo_clear() -> bool {
         let conf = SERIAL_JTAG_CONF_REG as *mut u32;
-        unsafe { conf.read_volatile() & 0b011 != 0b000 }
+        unsafe { conf.read_volatile() & 0b010 != 0b000 }
     }
 
     fn fifo_write(byte: u8) {


### PR DESCRIPTION
cc #53 - this is a sufficient workaround for my application to not generate broken defmt frames.

I suspect the issue with lost bytes is that defmt calls write_bytes in rapid succession and the host may not have enough time to poll the interface between writes. This PR just tries to increase the timeout but there should be better ways to handle this that results in better FIFO utilisation.