### PR TITLE
Don't double-lock in defmt

### DIFF
--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -84,5 +84,5 @@ unsafe impl defmt::Logger for Logger {
 }
 
 fn do_write(bytes: &[u8]) {
-    Printer.write_bytes(bytes)
+    Printer.write_bytes_assume_cs(bytes)
 }


### PR DESCRIPTION
The defmt implementation already creates a critical section if enabled. It needs to, because the framing must not be interspersed with other output. This PR removes an inner lock in the do_write calls, making the driver a bit lighter.

Since we're waiting for the FIFO to clear this may not have any significant runtime effect.