### PR TITLE
Fix RTT channel name when using defmt-espflash

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If this simple logger implementation isn't sufficient for your needs you can imp
 
 Using the `defmt-espflash` feature, esp-println will install a defmt global logger. The logger will
 output to the same data stream as `println!()`, and adds framing bytes so it can be used even with
-other, non-defmt output. Using the `defmt` feature automatically uses the Rzcobs encoding and does
+other, non-defmt output. Using the `defmt-espflash` feature automatically uses the Rzcobs encoding and does
 not allow changing the encoding.
 
 You can also use the `defmt-raw` feature that allows using any encoding provided by defmt, but

--- a/src/rtt.rs
+++ b/src/rtt.rs
@@ -32,15 +32,15 @@ pub struct ControlBlock {
     up: Buffer,
 }
 
-// When the defmt-raw feature is enabled along with rtt, we know we will be
+// When one of the defmt features is enabled along with rtt, we know we will be
 // interacting with a debugger by setting the channel name appropriatley we
 // allow the host to infer the data format of the stream. We also set the link
 // section of this name so the entire header can fit into RAM for easier
 // debugger access.
-#[cfg(feature = "defmt-raw")]
+#[cfg(any(feature = "defmt-raw", feature = "defmt-espflash"))]
 #[link_section = ".data"]
 static CHANNEL_NAME: [u8; 6] = *b"defmt\0";
-#[cfg(not(feature = "defmt-raw"))]
+#[cfg(not(any(feature = "defmt-raw", feature = "defmt-espflash")))]
 #[link_section = ".data"]
 static CHANNEL_NAME: [u8; 9] = *b"Terminal\0";
 


### PR DESCRIPTION
There is no reason to not set the channel name to `defmt\0` when using feature `defmt-espflash`, since probe-rs/defmt-decoder is perfectly capable of decoding rzcobs (with the added benefit of allowing recovery when non-defmt data has been received).