### PR TITLE
docs: Fix format

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can now `println!("Hello world")` as usual.
      output using `defmt` macros, or you may irrecoverably corrupt the output stream! This means that even the bootloader's output
      must be disabled.
 
-   `defmt` features can also be used with [`probe-rs`].
+`defmt` features can also be used with [`probe-rs`].
 
 [`probe-rs`]: https://probe.rs/
 


### PR DESCRIPTION
The features section is not properly formatted because of that last line, atm:
![image](https://github.com/esp-rs/esp-println/assets/12926049/4801d680-f142-47d0-9f9b-f234a7b2a6ef)
instead of:
![image](https://github.com/esp-rs/esp-println/assets/12926049/07d80b72-1c55-426a-ac0c-7c98e9ae543a)
