### PR TITLE
Reducing the worst case FIFO-origin latency

### DIFF
--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -53,6 +53,8 @@ unsafe impl defmt::Logger for Logger {
         // section.
         ENCODER.end_frame(do_write);
 
+        Printer.flush();
+
         #[cfg(feature = "critical-section")]
         {
             // We don't need to write a custom end-of-frame sequence because:
@@ -72,7 +74,9 @@ unsafe impl defmt::Logger for Logger {
         }
     }
 
-    unsafe fn flush() {}
+    unsafe fn flush() {
+        Printer.flush();
+    }
 
     unsafe fn write(bytes: &[u8]) {
         // safety: accessing the `static mut` is OK because we have acquired a critical

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,9 +128,6 @@ mod serial_jtag_printer {
     /// forever if there is no host attached.
     static mut TIMED_OUT: bool = false;
 
-    /// How many times flush has been called since last timeout
-    static mut NUM_CALLS_AFTER_TIME_OUT: u8 = 0;
-
     fn fifo_flush() {
         let conf = SERIAL_JTAG_CONF_REG as *mut u32;
         unsafe { conf.write_volatile(0b001) };
@@ -153,6 +150,11 @@ mod serial_jtag_printer {
                     // Still wasn't able to drain the FIFO - early return
                     // This is important so we don't block forever if there is no host attached.
                     return;
+                } else {
+                    unsafe {
+                        // Good to go!
+                        TIMED_OUT = false;
+                    }
                 }
             }
 
@@ -166,22 +168,6 @@ mod serial_jtag_printer {
 
         pub fn flush(&mut self) {
             const TIMEOUT_ITERATIONS: usize = 1_000;
-
-            if unsafe { TIMED_OUT } {
-                if !fifo_clear() & unsafe { NUM_CALLS_AFTER_TIME_OUT < 20 } {
-                    // Still wasn't able to drain the FIFO - early return
-                    // This is important so we don't block forever if there is no host attached.
-                    unsafe {
-                        NUM_CALLS_AFTER_TIME_OUT += 1;
-                    }
-                    return;
-                } else {
-                    unsafe {
-                        TIMED_OUT = false;
-                        NUM_CALLS_AFTER_TIME_OUT = 0;
-                    }
-                }
-            }
 
             fifo_flush();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,15 @@ mod serial_jtag_printer {
         }
 
         pub fn flush(&mut self) {
-            const TIMEOUT_ITERATIONS: usize = 50_000;
+            const TIMEOUT_ITERATIONS: usize = 5_000;
+
+            if unsafe { TIMED_OUT } {
+                if !fifo_clear() {
+                    // Still wasn't able to drain the FIFO - early return
+                    // This is important so we don't block forever if there is no host attached.
+                    return;
+                }
+            }
 
             fifo_flush();
 


### PR DESCRIPTION
Without this sometimes the FIFO goes full and never comes back

This amortized the FIFO latency and reduced the max latency to 1000 cycles