### PR TITLE
Don't mandate raw encoding with defmt-raw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ no-op       = []
 # Enables a `defmt` backend usable with espflash. We force rzcobs encoding to simplify implementation
 defmt-espflash = ["dep:defmt", "defmt?/encoding-rzcobs"]
 
-# Enables `defmt` with raw encoding.
-defmt-raw = ["dep:defmt", "defmt?/encoding-raw"]
+# Enables raw (unaltered) `defmt`.
+defmt-raw = ["dep:defmt"]
 
 # logging sub-features
 colors      = []

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ You can now `println!("Hello world")` as usual.
    - Only effective when using the `log` feature.
 - `critical-section` enables critical sections.
 - There are two ways to use this library with [`defmt`]:
-   - `defmt-espflash`: This is intended to be used with [`espflash`], see `-L/--log-format` argument of `flash` or `monitor` subcommands of `espflash` and `cargo-espflash`.
-     Uses [rzCOBS] encoding and adds framing.
-   - `defmt-raw`: Raw defmt output without additional framing. ⚠️ Be careful when using this feature: you must only write
-     output using `defmt` macros, or you may irrecoverably corrupt the output stream! This means that even the bootloader's output
-     must be disabled.
+   - `defmt-espflash`: This is intended to be used with [`espflash`], see `-L/--log-format` argument
+      of `flash` or `monitor` subcommands of `espflash` and `cargo-espflash`. Uses [rzCOBS] encoding
+      and adds framing.
+   - `defmt-raw`: Raw defmt output without additional framing. This feature does not prescribe an
+      encoding method. ⚠️ Be careful when using this feature with `uart` or `jtag-serial`: you must
+      only write output using `defmt` macros, or you may irrecoverably corrupt the output stream!
+      This means that even the bootloader's output must be disabled.
 
 `defmt` features can also be used with [`probe-rs`].
 


### PR DESCRIPTION
This PR makes the following line in the readme true:

> You can also use the `defmt-raw` feature that allows using any encoding provided by `defmt`, but
does not add extra framing.