### PR TITLE
Version 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp-println"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
     "Jesse Braham <jesse@beta7.io>",
@@ -17,7 +17,7 @@ cargo-args = ["-Z", "build-std=core"]
 
 [dependencies]
 log = { version = "0.4.20", optional = true }
-defmt = { version = "=0.3.5", optional = true }
+defmt = { version = "0.3.6", optional = true }
 critical-section = { version = "1.1.2", optional = true }
 portable-atomic = { version = "1.6.0", default-features = false, optional = true }
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ not allow changing the encoding.
 Follow the [`defmt` book's setup instructions] on how to
 set up `defmt`. Remember, the global logger is already installed for you by `esp-println`!
 
+Please note that `defmt` does _not_ provide MSRV guarantees with releases, and as such we are not able to make any MSRV guarantees when this feature is enabled. For more information refer to the MSRV section of `defmt`'s README:  
+https://github.com/knurling-rs/defmt?tab=readme-ov-file#msrv
+
 [`defmt`]: https://github.com/knurling-rs/defmt
 [`log` crate]: https://github.com/rust-lang/log
 [rzCOBS]: https://github.com/Dirbaio/rzcobs


### PR DESCRIPTION
- Are we happy with doing a patch release for this (`defmt` is feature gated, anyway), or should this be a minor release?
- Should we mention that `defmt` does not provide MSRV guarantees in `README.md`?